### PR TITLE
Add hostnamectl to build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+hostnamectl set-hostname james-os
+
 ###############################################################################
 # 0. Directories that must exist during the RPM unpack phase
 ###############################################################################


### PR DESCRIPTION
## Summary
- set hostname in build script

## Testing
- `shellcheck build.sh` *(fails: command not found)*
- `shfmt -d build.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842560b8d488332b64208acd8a34149