### PR TITLE
Replace gamescope with COPR build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -37,9 +37,17 @@ EOF
 rpm --import https://packages.microsoft.com/keys/microsoft.asc
 
 ###############################################################################
+# 3. Gamescope Git repo from COPR
+###############################################################################
+curl -L -o /etc/yum.repos.d/vulongm-gamescope-git.repo \
+  "https://copr.fedorainfracloud.org/coprs/vulongm/gamescope-git/repo/fedora-\$releasever/vulongm-gamescope-git-fedora-\$releasever.repo"
+rpm --import https://download.copr.fedorainfracloud.org/results/vulongm/gamescope-git/pubkey.gpg
+
+###############################################################################
 # 3. Install all desired packages in one shot
 ###############################################################################
 dnf5 makecache -y
+dnf5 remove -y gamescope || true
 dnf5 install -y \
   1password \
   1password-cli \
@@ -48,6 +56,7 @@ dnf5 install -y \
   piper \
   yakuake \
   corectrl \
+  gamescope \
   https://github.com/Legcord/Legcord/releases/download/v1.1.5/Legcord-1.1.5-linux-x86_64.rpm
 
 # Update plasma desktop and KDE components
@@ -91,6 +100,6 @@ EOF
 ###############################################################################
 # 6. Optional cleanup – drop repo files & dnf caches to keep image lean
 ###############################################################################
-rm -f /etc/yum.repos.d/1password.repo /etc/yum.repos.d/vscode.repo
+rm -f /etc/yum.repos.d/1password.repo /etc/yum.repos.d/vscode.repo /etc/yum.repos.d/vulongm-gamescope-git.repo
 dnf5 clean all
 rm -rf /var/cache/dnf

--- a/build.sh
+++ b/build.sh
@@ -39,9 +39,9 @@ rpm --import https://packages.microsoft.com/keys/microsoft.asc
 ###############################################################################
 # 3. Gamescope Git repo from COPR
 ###############################################################################
-curl -L -o /etc/yum.repos.d/vulongm-gamescope-git.repo \
-  "https://copr.fedorainfracloud.org/coprs/vulongm/gamescope-git/repo/fedora-\$releasever/vulongm-gamescope-git-fedora-\$releasever.repo"
-rpm --import https://download.copr.fedorainfracloud.org/results/vulongm/gamescope-git/pubkey.gpg
+# Install the copr plugin then enable the gamescope-git repo
+dnf5 install -y 'dnf-command(copr)'
+dnf5 copr enable -y vulongm/gamescope-git
 
 ###############################################################################
 # 3. Install all desired packages in one shot
@@ -100,6 +100,8 @@ EOF
 ###############################################################################
 # 6. Optional cleanup – drop repo files & dnf caches to keep image lean
 ###############################################################################
-rm -f /etc/yum.repos.d/1password.repo /etc/yum.repos.d/vscode.repo /etc/yum.repos.d/vulongm-gamescope-git.repo
+rm -f /etc/yum.repos.d/1password.repo \
+       /etc/yum.repos.d/vscode.repo \
+       /etc/yum.repos.d/_copr:copr.fedorainfracloud.org:vulongm:gamescope-git.repo
 dnf5 clean all
 rm -rf /var/cache/dnf

--- a/build.sh
+++ b/build.sh
@@ -47,7 +47,7 @@ dnf5 copr enable -y vulongm/gamescope-git
 # 3. Install all desired packages in one shot
 ###############################################################################
 dnf5 makecache -y
-dnf5 remove -y gamescope || true
+dnf5 remove -y gamescope gamescope-libs || true
 dnf5 install -y \
   1password \
   1password-cli \

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ###############################################################################
-# 0. Directories that must exist during the RPM unpack phase
+# Directories that must exist during the RPM unpack phase
 ###############################################################################
 mkdir -p /etc/yum.repos.d
 mkdir -p /var/opt               # /opt → /var/opt symlink target on Silverblue/Bazzite
@@ -23,7 +23,7 @@ EOF
 rpm --import https://downloads.1password.com/linux/keys/1password.asc
 
 ###############################################################################
-# 2. Visual Studio Code repo + key
+# Visual Studio Code repo + key
 ###############################################################################
 cat > /etc/yum.repos.d/vscode.repo <<'EOF'
 [code]
@@ -37,14 +37,14 @@ EOF
 rpm --import https://packages.microsoft.com/keys/microsoft.asc
 
 ###############################################################################
-# 3. Gamescope Git repo from COPR
+# Gamescope Git repo from COPR
 ###############################################################################
 # Install the copr plugin then enable the gamescope-git repo
 dnf5 install -y 'dnf-command(copr)'
 dnf5 copr enable -y vulongm/gamescope-git
 
 ###############################################################################
-# 3. Install all desired packages in one shot
+# Install all desired packages in one shot
 ###############################################################################
 dnf5 makecache -y
 dnf5 remove -y gamescope gamescope-libs || true
@@ -65,12 +65,12 @@ dnf5 update -y \
   plasma-workspace
 
 ###############################################################################
-# 4. Relocate 1Password into /usr (so it's captured in the OSTree commit)
+# Relocate 1Password into /usr (so it's captured in the OSTree commit)
 ###############################################################################
 mv /var/opt/1Password /usr/lib/1Password
 
 ###############################################################################
-# 5. Permissions, groups, hardening
+# Permissions, groups, hardening
 ###############################################################################
 # Choose high numeric GIDs that won't collide with regular user groups
 GID_ONEPASSWORD=1500
@@ -98,7 +98,7 @@ L /var/opt/1Password - - - - /usr/lib/1Password
 EOF
 
 ###############################################################################
-# 6. Optional cleanup – drop repo files & dnf caches to keep image lean
+# Optional cleanup – drop repo files & dnf caches to keep image lean
 ###############################################################################
 rm -f /etc/yum.repos.d/1password.repo \
        /etc/yum.repos.d/vscode.repo \


### PR DESCRIPTION
## Summary
- add vulongm gamescope COPR repo to build script
- remove existing gamescope and install COPR version
- clean up the repo file during build

## Testing
- `bash -n build.sh`


------
https://chatgpt.com/codex/tasks/task_e_6847e29656e48332889887f0e4695d2c