### PR TITLE
Remove Legcord from build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -47,8 +47,7 @@ dnf5 install -y \
   konsole \
   piper \
   yakuake \
-  corectrl \
-  https://github.com/Legcord/Legcord/releases/download/v1.1.5/Legcord-1.1.5-linux-x86_64.rpm
+  corectrl
 
 # Update plasma desktop and KDE components
 dnf5 update -y \


### PR DESCRIPTION
## Summary
- stop installing the Legcord RPM

## Testing
- `bash -n build.sh`
- `shellcheck build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6848a70a234c8332a7ff8fb44b4beb86