### PR TITLE
Remove rpm-ostree integration

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -51,7 +51,6 @@ dnf5 install -y \
   plasma-discover \
   plasma-discover-kns \
   plasma-discover-flatpak \
-  plasma-discover-rpm-ostree \
   plasma-discover-notifier \
   kde-partitionmanager
 


### PR DESCRIPTION
## Summary
- remove the `plasma-discover-rpm-ostree` package from build.sh

## Testing
- `just lint` *(fails: Unknown attribute `group`)*
- `just check` *(fails: Unknown attribute `group`)*

------
https://chatgpt.com/codex/tasks/task_e_6870c34985b483329beb9635cd1654c9