### PR TITLE
chore: remove unnecessary plasma/KDE explicit update from build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -54,11 +54,6 @@ dnf5 install -y \
   plasma-discover-notifier \
   kde-partitionmanager
 
-# Update plasma desktop and KDE components
-dnf5 update -y \
-  plasma-desktop \
-  plasma-workspace
-
 ###############################################################################
 # Remove unwanted packages
 ###############################################################################


### PR DESCRIPTION
This PR removes an unnecessary explicit 'dnf5 update' of 'plasma-desktop' and 'plasma-workspace' from build.sh.

Reasoning:
- The script already installs required packages earlier with 'dnf5 install'.
- Explicitly calling 'dnf5 update' for package names during image build is redundant and can lengthen build time.

No functional changes beyond removing the redundant update line.