### PR TITLE
[codex] add patch to image packages

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,6 +35,7 @@ dnf5 install -y \
   konsole \
   nodejs \
   npm \
+  patch \
   piper \
   yakuake \
   corectrl \


### PR DESCRIPTION
## What changed
Adds the host `patch` package to the image build package list.

## Why
`uupd` reported `Brew Upgrade` as failed because Homebrew had to build `llvm` from source on this system, and that build invokes `patch`. The host image did not include the `patch` package, so the build environment could not satisfy that dependency.

## Impact
Future images include `patch` on the host, which should allow Homebrew source builds that require it to proceed.

## Validation
- `bash -n build.sh`
- Confirmed the change is limited to adding `patch` to the `dnf5 install` list
