### PR TITLE
[codex] Fix KDE Discord lock sync

### DIFF
--- a/system/usr_local_bin__kde-discord-idle-sync.py
+++ b/system/usr_local_bin__kde-discord-idle-sync.py
@@ -3,6 +3,7 @@
 import os
 import socket
 import subprocess
+import sys
 import time
 
 
@@ -10,8 +11,11 @@ SOCKET_PATH = os.environ.get(
     "VENCORD_KDE_IDLE_SOCKET",
     os.path.join(os.environ.get("XDG_RUNTIME_DIR", "/tmp"), "vencord-kde-idle-sync.sock"),
 )
-IDLE_THRESHOLD_SECONDS = int(os.environ.get("VENCORD_KDE_IDLE_THRESHOLD", "300"))
 POLL_SECONDS = float(os.environ.get("VENCORD_KDE_IDLE_POLL_SECONDS", "5"))
+
+
+def log(message: str) -> None:
+    print(f"kde-discord-idle-sync: {message}", file=sys.stderr, flush=True)
 
 
 def dbus_call(method: str) -> str:
@@ -38,11 +42,6 @@ def get_lock_state() -> bool:
     return dbus_call("GetActive").lower().endswith("true,)")
 
 
-def get_idle_seconds() -> int:
-    output = dbus_call("GetSessionIdleTime")
-    return int(output.removeprefix("(uint32 ").removesuffix(",)"))
-
-
 def notify_vencord(state: str) -> None:
     with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
         client.settimeout(1)
@@ -55,12 +54,13 @@ def main() -> None:
 
     while True:
         try:
-            state = "inactive" if get_lock_state() or get_idle_seconds() >= IDLE_THRESHOLD_SECONDS else "active"
+            state = "inactive" if get_lock_state() else "active"
+
             if state != last_state:
                 notify_vencord(state)
                 last_state = state
-        except Exception:
-            pass
+        except Exception as error:
+            log(f"poll failed: {error}")
 
         time.sleep(POLL_SECONDS)
 

--- a/vencord-overlay/src/plugins/kdeIdleSync.discordDesktop/index.ts
+++ b/vencord-overlay/src/plugins/kdeIdleSync.discordDesktop/index.ts
@@ -14,8 +14,6 @@ const StatusSettings = getUserSettingLazy<string>("status", "status")!;
 
 type ManagedStatus = "online" | "idle" | "dnd" | "invisible";
 
-let savedStatus: string | null = null;
-
 const settings = definePluginSettings({
     inactiveStatus: {
         type: OptionType.SELECT,
@@ -32,7 +30,9 @@ const settings = definePluginSettings({
         description: "Restore your previous status when activity resumes",
         default: true
     }
-});
+}).withPrivateSettings<{
+    savedStatus?: ManagedStatus | null;
+}>();
 
 function getCurrentStatus() {
     return StatusSettings.getSetting();
@@ -74,8 +74,8 @@ export default definePlugin({
             return;
         }
 
-        if (savedStatus == null) {
-            savedStatus = current;
+        if (settings.store.savedStatus == null) {
+            settings.store.savedStatus = current as ManagedStatus;
         }
 
         setStatus(inactiveStatus);
@@ -83,17 +83,18 @@ export default definePlugin({
 
     applyActiveState() {
         if (!settings.store.restoreStatusOnActive) {
-            savedStatus = null;
+            settings.store.savedStatus = null;
             return;
         }
 
         const inactiveStatus = settings.store.inactiveStatus as ManagedStatus;
         const current = getCurrentStatus();
+        const savedStatus = settings.store.savedStatus as ManagedStatus | null | undefined;
 
         if (savedStatus != null && current === inactiveStatus) {
-            setStatus(savedStatus as ManagedStatus);
+            setStatus(savedStatus);
         }
 
-        savedStatus = null;
+        settings.store.savedStatus = null;
     }
 });


### PR DESCRIPTION
## What changed
- changed the KDE Discord sync watcher to use lock state only instead of idle-time detection
- persisted the plugin's saved pre-inactive status so it can restore correctly after reloads or restarts

## Why
The previous watcher depended on `GetSessionIdleTime`, which is not supported on this KDE Wayland setup. That caused unreliable status changes. Separately, the plugin stored the previous status only in renderer memory, so Discord could get stuck in the extension-applied idle state after a reload.

## Impact
- Discord status now tracks actual screen lock/unlock instead of idle heuristics
- active state restoration is resilient across plugin reloads and Discord restarts
- the extension is less likely to misclassify an active session as idle on KDE

## Validation
- `python3 -m py_compile system/usr_local_bin__kde-discord-idle-sync.py`
- verified `org.freedesktop.ScreenSaver.GetActive` reports the live lock state
- restarted the user service locally and confirmed the watcher stayed healthy
