### PR TITLE
Run KVM display recovery under Wayland

### DIFF
--- a/system/usr_lib_systemd_user__kvm-display-recover.service
+++ b/system/usr_lib_systemd_user__kvm-display-recover.service
@@ -7,6 +7,7 @@ PartOf=graphical-session.target
 Type=simple
 EnvironmentFile=-/etc/kvm-display-recover.env
 EnvironmentFile=-%h/.config/kvm-display-recover.env
+Environment=QT_QPA_PLATFORM=wayland
 ExecStart=/usr/local/bin/kvm-display-recover
 Restart=always
 RestartSec=1


### PR DESCRIPTION
## Summary
- force the KVM display recovery user service to run `kscreen-doctor` under Wayland
- avoid the Qt xcb platform plugin crash observed under systemd user services on James OS

## Testing
- verified `systemd-run --user --wait --collect -E QT_QPA_PLATFORM=wayland /usr/bin/kscreen-doctor -j` succeeds on a live James OS session
- confirmed the local service environment fix removes the prior xcb crash path in journal output