### PR TITLE
[codex] Add Konsole Codex desktop update shortcut

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -7,14 +7,17 @@ ENV GNUPGHOME=/var/tmp/gnupg
 # Copy in baked config files
 COPY --chmod=0644 system/etc__hostname /etc/hostname
 COPY --chmod=0644 system/etc__kvm-display-recover.env /etc/kvm-display-recover.env
+COPY --chmod=0644 system/etc_ublue-os__topgrade.toml /etc/ublue-os/topgrade.toml
 COPY --chmod=0644 system/etc__vencord-kde-idle-sync.env /etc/vencord-kde-idle-sync.env
 COPY --chmod=0755 system/usr_local_bin__discord_encoder.py /usr/local/bin/discord_encoder.py
 COPY --chmod=0755 system/usr_local_bin__dolphin_discord_encode.py /usr/local/bin/dolphin_discord_encode.py
+COPY --chmod=0755 system/usr_local_bin__topgrade-codex-desktop-linux-update /usr/local/bin/topgrade-codex-desktop-linux-update
 COPY --chmod=0755 system/usr_local_bin__kvm-display-recover /usr/local/bin/kvm-display-recover
 COPY --chmod=0755 system/usr_local_bin__kde-discord-idle-sync.py /usr/local/bin/kde-discord-idle-sync.py
 COPY --chmod=0644 system/usr_lib_systemd_user__kvm-display-recover.service /usr/lib/systemd/user/kvm-display-recover.service
 COPY --chmod=0644 system/usr_lib_systemd_user__kde-discord-idle-sync.service /usr/lib/systemd/user/kde-discord-idle-sync.service
 COPY --chmod=0644 system/usr_share_applications__discord-h264-encode.desktop /usr/share/applications/discord-h264-encode.desktop
+COPY --chmod=0644 system/usr_share_applications__system-update.desktop /usr/share/applications/system-update.desktop
 
 RUN chmod +x /tmp/build.sh && \
     mkdir -p "$GNUPGHOME" /var/lib/alternatives && chmod 700 "$GNUPGHOME" && \

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A [Fedora Atomic](https://fedoraproject.org/atomic-desktops) image built with [U
 - Removes Lutris.
 - Preinstalls 1Password and the 1Password CLI.
 - Adds back Konsole as a terminal option and Yakuake to complement it (ptyxis remains the default for compatibility with some Bazzite features).
+- Launches the System Update shortcut in Konsole and includes a Topgrade custom step for a local `codex-desktop-linux` checkout.
 - Preinstalls Piper for configuring mice.
 - Preinstalls CoreCtrl for power management.
 - Adds an Open With action in Dolphin to encode videos for Discord using CPU H.264 with a target-size popup and progress bar.

--- a/build.sh
+++ b/build.sh
@@ -32,6 +32,7 @@ dnf5 makecache -y
 dnf5 install -y \
   1password \
   1password-cli \
+  cargo \
   konsole \
   nodejs \
   npm \

--- a/system/etc_ublue-os__topgrade.toml
+++ b/system/etc_ublue-os__topgrade.toml
@@ -1,0 +1,4 @@
+[commands]
+"Mozilla GNOME Themes" = "/usr/libexec/topgrade/mozilla-gnome-theme-update"
+"Third Party CSS Loader Themes" = "/usr/libexec/topgrade/third-party-css-loader-update"
+"Codex Desktop Linux" = "/usr/local/bin/topgrade-codex-desktop-linux-update"

--- a/system/usr_local_bin__topgrade-codex-desktop-linux-update
+++ b/system/usr_local_bin__topgrade-codex-desktop-linux-update
@@ -27,6 +27,9 @@ STATE_DIR="${XDG_STATE_HOME:-${HOME}/.local/state}/codex-desktop-linux"
 INSTALL_ENV="${STATE_DIR}/install.env"
 DMG_FILE="${REPO_DIR}/Codex.dmg"
 
+# Avoid interactive npx package-install prompts during unattended Topgrade runs.
+export npm_config_yes=true
+
 write_install_env() {
     mkdir -p "$STATE_DIR"
     {

--- a/system/usr_local_bin__topgrade-codex-desktop-linux-update
+++ b/system/usr_local_bin__topgrade-codex-desktop-linux-update
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_candidates=(
+    "${CODEX_DESKTOP_LINUX_REPO:-}"
+    "${HOME}/codex-desktop-linux"
+    "${HOME}/Projects/codex-desktop-linux"
+    "${HOME}/workspace/codex-desktop-linux"
+)
+
+REPO_DIR=""
+for candidate in "${repo_candidates[@]}"; do
+    if [ -n "$candidate" ] && [ -d "$candidate/.git" ]; then
+        REPO_DIR="$candidate"
+        break
+    fi
+done
+
+if [ -z "$REPO_DIR" ]; then
+    echo "codex-desktop-linux checkout not found; set CODEX_DESKTOP_LINUX_REPO." >&2
+    exit 1
+fi
+
+OPT_ROOT="${HOME}/.local/opt/codex-desktop-linux"
+APP_DIR="${OPT_ROOT}/codex-app"
+STATE_DIR="${XDG_STATE_HOME:-${HOME}/.local/state}/codex-desktop-linux"
+INSTALL_ENV="${STATE_DIR}/install.env"
+DMG_FILE="${REPO_DIR}/Codex.dmg"
+
+write_install_env() {
+    mkdir -p "$STATE_DIR"
+    {
+        printf 'REPO_DIR=%q\n' "$REPO_DIR"
+        printf 'OPT_ROOT=%q\n' "$OPT_ROOT"
+        printf 'APP_DIR=%q\n' "$APP_DIR"
+        printf 'DMG_FILE=%q\n' "$DMG_FILE"
+    } > "$INSTALL_ENV"
+}
+
+patch_installed_common() {
+    local common="${OPT_ROOT}/lib/codex-desktop-linux/common.sh"
+    [ -f "$common" ] || return 0
+    grep -q 'Fallback when Pillow is unavailable' "$common" && return 0
+    python3 - "$common" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+needle = """extract_icon() {
+    ensure_layout
+"""
+replacement = """extract_icon() {
+    ensure_layout
+    # Fallback when Pillow is unavailable in the system Python.
+    if ! python3 - <<'PYCHECK' >/dev/null 2>&1
+import PIL
+PYCHECK
+    then
+        if [ -f "$REPO_DIR/assets/codex.png" ]; then
+            cp "$REPO_DIR/assets/codex.png" "$ICON_PATH"
+            return 0
+        fi
+    fi
+
+"""
+if needle in text:
+    path.write_text(text.replace(needle, replacement, 1))
+PY
+}
+
+old_head="$(git -C "$REPO_DIR" rev-parse HEAD)"
+git -C "$REPO_DIR" pull --ff-only
+new_head="$(git -C "$REPO_DIR" rev-parse HEAD)"
+
+if [ -x "$REPO_DIR/contrib/user-local-install/install-user-local.sh" ]; then
+    "$REPO_DIR/contrib/user-local-install/install-user-local.sh" --from-update
+fi
+
+write_install_env
+patch_installed_common
+
+if [ "$old_head" != "$new_head" ]; then
+    exec "$HOME/.local/bin/codex-desktop-update" --force
+fi
+
+exec "$HOME/.local/bin/codex-desktop-update"

--- a/system/usr_share_applications__system-update.desktop
+++ b/system/usr_share_applications__system-update.desktop
@@ -1,0 +1,16 @@
+[Desktop Entry]
+Type=Application
+Name=System Update
+Name[cs]=Aktualizace systému
+Name[fr]=Mises à jour
+Name[el]=Ενημέρωση συστήματος
+Name[ru]=Обновление системы
+Comment=Update Bazzite, Flatpaks, and more
+Comment[cs]=Aktualizace Bazzite, Flatpaků a dalších
+Comment[fr]=Met à jour Bazzite, les applications et plus encore
+Comment[el]=Ενημερώνει το Bazzite, τα Flatpaks και άλλα
+Comment[ru]=Обновить Bazzite, Flatpak и многое другое
+Icon=/usr/share/ublue-os/bazzite/update.svg
+Categories=ConsoleOnly;System;
+Terminal=false
+Exec=konsole -e /usr/bin/ujust update


### PR DESCRIPTION
## Summary

- run the System Update desktop shortcut through Konsole instead of the environment default terminal
- add a Bazzite Topgrade custom command for updating a local `codex-desktop-linux` checkout and rebuilt user-local Codex Desktop app
- bake the Codex update helper into `/usr/local/bin` and include it from `/etc/ublue-os/topgrade.toml`

## Why

The stock System Update shortcut launches `ujust update`, which uses Bazzite's Topgrade config and whichever terminal handler the desktop chooses. That meant the Codex Desktop updater was not included in shortcut-driven updates, and the local workaround could open nested Ptyxis windows.

This keeps the normal `ujust update` flow, but forces the graphical shortcut to open in Konsole and lets Bazzite's existing Topgrade include path pick up the Codex updater.

## Validation

- `bash -n system/usr_local_bin__topgrade-codex-desktop-linux-update`
- `desktop-file-validate system/usr_share_applications__system-update.desktop`
- `git diff --check`
