### PR TITLE
[codex] Install cargo in the image

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,6 +32,7 @@ dnf5 makecache -y
 dnf5 install -y \
   1password \
   1password-cli \
+  cargo \
   konsole \
   nodejs \
   npm \


### PR DESCRIPTION
## Summary

- install `cargo` in the base image package set

## Why

The local `codex-desktop-linux` update flow can build the Linux Computer Use plugin backend when `cargo` is available on `PATH`. Without it, the update completes but warns that the plugin will be unavailable.

Because the System Update shortcut runs from the image environment, this is best handled as an OS-level package in the image build rather than a separate user-local Homebrew dependency.

## Validation

- verified the change is limited to `build.sh`
- ran `git diff --check`
