### PR TITLE
[codex] Use Fedora stock kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A [Fedora Atomic](https://fedoraproject.org/atomic-desktops) image built with [Universal Blue](https://universal-blue.org/)’s toolkit.
 
 ## Changes from Bazzite
+- Uses Fedora's stock kernel instead of Bazzite's OGC kernel.
 - Replaces GNOME Disk Utility with KDE Partition Manager.
 - Removes Lutris.
 - Preinstalls 1Password and the 1Password CLI.

--- a/build.sh
+++ b/build.sh
@@ -29,6 +29,34 @@ rpm --import https://downloads.1password.com/linux/keys/1password.asc
 # Install all desired packages in one shot
 ###############################################################################
 dnf5 makecache -y
+
+###############################################################################
+# Replace Bazzite's OGC kernel with Fedora's stock kernel
+###############################################################################
+dnf5 versionlock delete \
+  kernel \
+  kernel-core \
+  kernel-devel \
+  kernel-devel-matched \
+  kernel-modules
+
+dnf5 \
+  --setopt=fedora.exclude= \
+  --setopt=updates.exclude= \
+  --setopt=updates-archive.exclude= \
+  install -y \
+  kernel \
+  kernel-core \
+  kernel-devel \
+  kernel-devel-matched \
+  kernel-modules \
+  kernel-modules-core \
+  kernel-modules-extra \
+  kernel-tools \
+  kernel-tools-libs \
+  --allowerasing \
+  --best
+
 dnf5 install -y \
   1password \
   1password-cli \


### PR DESCRIPTION
## Summary

Swaps the image build from Bazzite's pinned OGC kernel to Fedora's stock kernel packages.

The build now removes Bazzite's kernel versionlocks, clears the Fedora repo kernel excludes for the install transaction, and installs the stock Fedora kernel package set, including `kernel-modules-core` and `kernel-modules-extra`.

## Impact

This lets the image track Fedora's stock kernel stream, which currently includes the CVE-2026-31431 fixed 6.19 line. Because the Bazzite OGC kernel is replaced, Bazzite's prebuilt kernel-module add-ons that depend on the OGC kernel are removed by the transaction.

## Validation

- `bash -n build.sh`
- `git diff --check`
- `podman build --pull=newer --tag localhost/james-os:stock-fedora-kernel-test .`
- Verified the built image contains `kernel-6.19.14-300.fc44.x86_64`, `kernel-core-6.19.14-300.fc44.x86_64`, `kernel-modules-6.19.14-300.fc44.x86_64`, `kernel-modules-core-6.19.14-300.fc44.x86_64`, and `kernel-modules-extra-6.19.14-300.fc44.x86_64`.

Note: the build still prints the existing Vencord installer root-user panic, but the build completes and commits the image.