### PR TITLE
[codex] Fix Vencord image patching

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -14,6 +14,7 @@ COPY --chmod=0755 system/usr_local_bin__dolphin_discord_encode.py /usr/local/bin
 COPY --chmod=0755 system/usr_local_bin__topgrade-codex-desktop-linux-update /usr/local/bin/topgrade-codex-desktop-linux-update
 COPY --chmod=0755 system/usr_local_bin__kvm-display-recover /usr/local/bin/kvm-display-recover
 COPY --chmod=0755 system/usr_local_bin__kde-discord-idle-sync.py /usr/local/bin/kde-discord-idle-sync.py
+COPY --chmod=0755 system/usr_local_bin__patch-discord-vencord-asar.mjs /usr/local/bin/patch-discord-vencord-asar.mjs
 COPY --chmod=0644 system/usr_lib_systemd_user__kvm-display-recover.service /usr/lib/systemd/user/kvm-display-recover.service
 COPY --chmod=0644 system/usr_lib_systemd_user__kde-discord-idle-sync.service /usr/lib/systemd/user/kde-discord-idle-sync.service
 COPY --chmod=0644 system/usr_share_applications__discord-h264-encode.desktop /usr/share/applications/discord-h264-encode.desktop

--- a/build.sh
+++ b/build.sh
@@ -108,8 +108,20 @@ export PATH="/tmp/npm-global/bin:${PATH}"
   cd /tmp/Vencord
   pnpm install --frozen-lockfile
   pnpm build
-  pnpm inject -- --location /usr/share/discord
+  install -Dm0644 dist/patcher.js /usr/share/vencord/patcher.js
+  install -Dm0644 dist/preload.js /usr/share/vencord/preload.js
+  install -Dm0644 dist/renderer.js /usr/share/vencord/renderer.js
+  install -Dm0644 dist/renderer.css /usr/share/vencord/renderer.css
 )
+
+node /usr/local/bin/patch-discord-vencord-asar.mjs
+test -f /usr/share/discord/resources/_app.asar
+test -f /usr/share/discord/resources/app.asar
+grep -aqF '/usr/share/vencord/patcher.js' /usr/share/discord/resources/app.asar
+test -f /usr/share/vencord/patcher.js
+test -f /usr/share/vencord/preload.js
+test -f /usr/share/vencord/renderer.js
+test -f /usr/share/vencord/renderer.css
 
 # Enable the KDE idle sync watcher for all users by default.
 mkdir -p /usr/lib/systemd/user/graphical-session.target.wants
@@ -124,7 +136,7 @@ ln -sfn /usr/lib/systemd/user/kvm-display-recover.service \
 ###############################################################################
 dnf5 remove -y gnome-disk-utility
 dnf5 remove -y lutris
-dnf5 remove -y nodejs npm
+dnf5 remove -y nodejs nodejs22 npm nodejs22-npm
 
 ###############################################################################
 # Relocate 1Password into /usr (so it's captured in the OSTree commit)

--- a/system/usr_local_bin__patch-discord-vencord-asar.mjs
+++ b/system/usr_local_bin__patch-discord-vencord-asar.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import { renameSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const discordResources = "/usr/share/discord/resources";
+const appAsar = join(discordResources, "app.asar");
+const originalAppAsar = join(discordResources, "_app.asar");
+const tempAppAsar = join(discordResources, "app.asar.tmp");
+const vencordPatcher = "/usr/share/vencord/patcher.js";
+
+const packageJson = `{
+    "name": "discord",
+    "main": "index.js"
+}`;
+
+function asarEntry(size, offset) {
+    return { size, offset: String(offset) };
+}
+
+function buildAsar(files) {
+    const headerFiles = {};
+    const chunks = [];
+    let offset = 0;
+
+    for (const [name, content] of Object.entries(files)) {
+        const bytes = Buffer.from(content);
+        headerFiles[name] = asarEntry(bytes.length, offset);
+        chunks.push(bytes);
+        offset += bytes.length;
+    }
+
+    const header = JSON.stringify({ files: headerFiles });
+    const headerBytes = Buffer.from(header);
+    const dataSize = 4;
+    const alignedSize = (headerBytes.length + dataSize - 1) & ~(dataSize - 1);
+    const headerSize = alignedSize + 8;
+    const headerObjectSize = alignedSize + dataSize;
+    const padding = Buffer.from("0".repeat(alignedSize - headerBytes.length));
+
+    const sizeHeader = Buffer.alloc(16);
+    sizeHeader.writeInt32LE(dataSize, 0);
+    sizeHeader.writeInt32LE(headerSize, 4);
+    sizeHeader.writeInt32LE(headerObjectSize, 8);
+    sizeHeader.writeInt32LE(headerBytes.length, 12);
+
+    return Buffer.concat([sizeHeader, headerBytes, padding, ...chunks]);
+}
+
+try {
+    renameSync(appAsar, originalAppAsar);
+
+    const indexJs = `require(${JSON.stringify(vencordPatcher)});`;
+    writeFileSync(tempAppAsar, buildAsar({
+        "index.js": indexJs,
+        "package.json": packageJson
+    }));
+    renameSync(tempAppAsar, appAsar);
+} catch (error) {
+    rmSync(tempAppAsar, { force: true });
+    throw new Error(`Failed to patch ${appAsar}: ${error.message}`);
+}
+
+console.log(`Patched ${appAsar} to load ${vencordPatcher}`);
+console.log(`Original Discord app archive moved to ${originalAppAsar}`);


### PR DESCRIPTION
## Summary
- Replace the Vencord installer CLI invocation with a deterministic image-build patch helper.
- Install the pinned Vencord desktop build into `/usr/share/vencord`.
- Add build-time assertions for the patched Discord `app.asar` and Vencord runtime files.

## Root Cause
The Vencord installer CLI panics when run as root without `SUDO_USER`/`DOAS_USER`, and Vencord’s Node wrapper can swallow that failure. The image build could continue while Discord was not actually patched.

## Validation
- `bash -n build.sh`
- `node --check system/usr_local_bin__patch-discord-vencord-asar.mjs`
- `just build localhost/james-os vencord-patch-pr-test`
- Verified the built image contains `/usr/share/discord/resources/_app.asar`, a patched `app.asar` requiring `/usr/share/vencord/patcher.js`, and `/usr/share/vencord/{patcher.js,preload.js,renderer.js,renderer.css}`.
- Verified `nodejs22` and `nodejs22-npm` are not installed in the final image.