### PR TITLE
[codex] Remove Bazaar from image

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A [Fedora Atomic](https://fedoraproject.org/atomic-desktops) image built with [U
 - Uses Fedora's stock kernel instead of Bazzite's OGC kernel.
 - Replaces GNOME Disk Utility with KDE Partition Manager.
 - Removes Lutris.
+- Removes Bazaar and its KRunner integration.
 - Preinstalls 1Password and the 1Password CLI.
 - Adds back Konsole as a terminal option and Yakuake to complement it (ptyxis remains the default for compatibility with some Bazzite features).
 - Launches the System Update shortcut in Konsole and includes a Topgrade custom step for a local `codex-desktop-linux` checkout.

--- a/build.sh
+++ b/build.sh
@@ -124,6 +124,7 @@ ln -sfn /usr/lib/systemd/user/kvm-display-recover.service \
 ###############################################################################
 dnf5 remove -y gnome-disk-utility
 dnf5 remove -y lutris
+dnf5 remove -y bazaar krunner-bazaar
 dnf5 remove -y nodejs npm
 
 ###############################################################################


### PR DESCRIPTION
## Summary
- remove the inherited Bazzite `bazaar` package during image customization
- remove the `krunner-bazaar` integration alongside it
- document that James OS removes Bazaar and its KRunner integration

## Compatibility notes
This removes Bazaar as the Flatpak app-store UI and removes the KRunner plugin that searches Flatpak apps through Bazaar. Flatpak itself remains installed in the inherited image, and the solver did not remove Flatpak KCM or Plasma Discover libraries.

The package solver also removes now-unused Bazaar runtime dependencies from the built image, including `webkitgtk6.0`, `javascriptcoregtk6.0`, `glycin-gtk4-libs`, `libdex`, `md4c`, plus related unused libraries in the full build. That should be fine for RPM-packaged image contents because no installed package requires them after Bazaar is removed, but it could affect manually layered software or local scripts that assumed those libraries were available from the base image.

## Validation
- `bash -n build.sh`
- `git diff --check`
- `podman build -t localhost/james-os:bazaar-removal-test .`
- `podman run --rm localhost/james-os:bazaar-removal-test bash -lc 'rpm -q bazaar krunner-bazaar; test ! -e /usr/bin/bazaar; test ! -e /usr/share/applications/io.github.kolunmi.Bazaar.desktop'`
