### PR TITLE
[codex] Disable DirtyFrag kernel modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+When Codex creates commits in this repository, include this trailer in the
+commit message:
+
+Co-Authored-By: Codex <codex@openai.com>

--- a/Containerfile
+++ b/Containerfile
@@ -7,6 +7,7 @@ ENV GNUPGHOME=/var/tmp/gnupg
 # Copy in baked config files
 COPY --chmod=0644 system/etc__hostname /etc/hostname
 COPY --chmod=0644 system/etc__kvm-display-recover.env /etc/kvm-display-recover.env
+COPY --chmod=0644 system/etc_modprobe.d__dirtyfrag.conf /etc/modprobe.d/dirtyfrag.conf
 COPY --chmod=0644 system/etc_ublue-os__topgrade.toml /etc/ublue-os/topgrade.toml
 COPY --chmod=0644 system/etc__vencord-kde-idle-sync.env /etc/vencord-kde-idle-sync.env
 COPY --chmod=0755 system/usr_local_bin__discord_encoder.py /usr/local/bin/discord_encoder.py

--- a/system/etc_modprobe.d__dirtyfrag.conf
+++ b/system/etc_modprobe.d__dirtyfrag.conf
@@ -1,0 +1,3 @@
+install esp4 /bin/false
+install esp6 /bin/false
+install rxrpc /bin/false


### PR DESCRIPTION
## Summary

Adds a baked `/etc/modprobe.d/dirtyfrag.conf` mitigation to block the vulnerable `esp4`, `esp6`, and `rxrpc` kernel modules from loading in the custom image.

Also adds a repo-level `AGENTS.md` instruction requiring future Codex commits to include the Codex co-author trailer.

## Why

The currently deployed Fedora 44 kernel on `james-os` matches a DirtyFrag-tested vulnerable kernel version. This image-level mitigation keeps the module blacklist persistent across rebuilds and redeploys until a patched kernel is available and booted.

## Validation

- Ran `git diff --check`
- Verified the branch contains the `Containerfile` copy line, the new modprobe config, and the repo `AGENTS.md`
- Manually applied the same mitigation on the live host and confirmed `esp4`, `esp6`, and `rxrpc` are blocked and not loaded
