### PR TITLE
[codex] Revert stock Fedora kernel swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 A [Fedora Atomic](https://fedoraproject.org/atomic-desktops) image built with [Universal Blue](https://universal-blue.org/)’s toolkit.
 
 ## Changes from Bazzite
-- Uses Fedora's stock kernel instead of Bazzite's OGC kernel.
 - Replaces GNOME Disk Utility with KDE Partition Manager.
 - Removes Lutris.
 - Preinstalls 1Password and the 1Password CLI.

--- a/build.sh
+++ b/build.sh
@@ -30,33 +30,6 @@ rpm --import https://downloads.1password.com/linux/keys/1password.asc
 ###############################################################################
 dnf5 makecache -y
 
-###############################################################################
-# Replace Bazzite's OGC kernel with Fedora's stock kernel
-###############################################################################
-dnf5 versionlock delete \
-  kernel \
-  kernel-core \
-  kernel-devel \
-  kernel-devel-matched \
-  kernel-modules
-
-dnf5 \
-  --setopt=fedora.exclude= \
-  --setopt=updates.exclude= \
-  --setopt=updates-archive.exclude= \
-  install -y \
-  kernel \
-  kernel-core \
-  kernel-devel \
-  kernel-devel-matched \
-  kernel-modules \
-  kernel-modules-core \
-  kernel-modules-extra \
-  kernel-tools \
-  kernel-tools-libs \
-  --allowerasing \
-  --best
-
 dnf5 install -y \
   1password \
   1password-cli \


### PR DESCRIPTION
## Summary

- remove the build-time replacement of Bazzite's OGC kernel with Fedora's stock kernel
- remove the README note claiming the image intentionally uses Fedora's stock kernel

## Why

The stock-kernel swap is no longer needed, and reverting it restores the image to Bazzite's default kernel packaging path. This also lets Ethernet diagnosis compare against the default Bazzite kernel stack again after a rebuild/rebase.

## Validation

- `bash -n build.sh`
- `git diff --check`

Note: a local shell startup hook emitted a `/usr/share/bazzite-cli/bling.sh` bind warning during these commands; the checks themselves passed.