### PR TITLE
[codex] Handle Discord bootstrap package layout

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -53,7 +53,14 @@ curl -L 'https://discord.com/api/download?platform=linux&format=tar.gz' \
   -o /tmp/discord.tar.gz
 mkdir -p /usr/share/discord
 tar -xzf /tmp/discord.tar.gz --strip-components=1 -C /usr/share/discord
-ln -sf /usr/share/discord/Discord /usr/bin/discord
+if [[ -x /usr/share/discord/Discord ]]; then
+  ln -sf /usr/share/discord/Discord /usr/bin/discord
+elif [[ -x /usr/share/discord/discord ]]; then
+  ln -sf /usr/share/discord/discord /usr/bin/discord
+else
+  echo "Discord executable not found in official tarball" >&2
+  exit 1
+fi
 install -Dm0644 /usr/share/discord/discord.desktop /usr/share/applications/discord.desktop
 if [[ -e /usr/share/discord/chrome-sandbox ]]; then
   chmod 4755 /usr/share/discord/chrome-sandbox
@@ -64,39 +71,43 @@ fi
 mkdir -p /usr/share/icons/hicolor/256x256/apps
 ln -sfn /usr/share/discord/discord.png /usr/share/icons/hicolor/256x256/apps/discord.png
 
-###############################################################################
-# Install Vencord into the image-level Discord tree with the KDE idle plugin
-###############################################################################
-git clone --depth=1 --branch "${VENCORD_TAG}" https://github.com/Vendicated/Vencord.git /tmp/Vencord
-git -C /tmp/Vencord checkout "${VENCORD_REF}"
-mkdir -p /tmp/Vencord/src/plugins/kdeIdleSync.discordDesktop
-cp /tmp/vencord-overlay/src/plugins/kdeIdleSync.discordDesktop/index.ts /tmp/Vencord/src/plugins/kdeIdleSync.discordDesktop/index.ts
-cp /tmp/vencord-overlay/src/plugins/kdeIdleSync.discordDesktop/native.ts /tmp/Vencord/src/plugins/kdeIdleSync.discordDesktop/native.ts
-export HOME=/tmp
-export XDG_CONFIG_HOME=/tmp/.config
-export XDG_DATA_HOME=/tmp/.local/share
-export npm_config_cache=/tmp/npm-cache
-export npm_config_prefix=/tmp/npm-global
-npm install -g pnpm@10.4.1
-export PATH="/tmp/npm-global/bin:${PATH}"
-(
-  cd /tmp/Vencord
-  pnpm install --frozen-lockfile
-  pnpm build
-  install -Dm0644 dist/patcher.js /usr/share/vencord/patcher.js
-  install -Dm0644 dist/preload.js /usr/share/vencord/preload.js
-  install -Dm0644 dist/renderer.js /usr/share/vencord/renderer.js
-  install -Dm0644 dist/renderer.css /usr/share/vencord/renderer.css
-)
+if [[ -f /usr/share/discord/resources/app.asar ]]; then
+  ###############################################################################
+  # Install Vencord into the image-level Discord tree with the KDE idle plugin
+  ###############################################################################
+  git clone --depth=1 --branch "${VENCORD_TAG}" https://github.com/Vendicated/Vencord.git /tmp/Vencord
+  git -C /tmp/Vencord checkout "${VENCORD_REF}"
+  mkdir -p /tmp/Vencord/src/plugins/kdeIdleSync.discordDesktop
+  cp /tmp/vencord-overlay/src/plugins/kdeIdleSync.discordDesktop/index.ts /tmp/Vencord/src/plugins/kdeIdleSync.discordDesktop/index.ts
+  cp /tmp/vencord-overlay/src/plugins/kdeIdleSync.discordDesktop/native.ts /tmp/Vencord/src/plugins/kdeIdleSync.discordDesktop/native.ts
+  export HOME=/tmp
+  export XDG_CONFIG_HOME=/tmp/.config
+  export XDG_DATA_HOME=/tmp/.local/share
+  export npm_config_cache=/tmp/npm-cache
+  export npm_config_prefix=/tmp/npm-global
+  npm install -g pnpm@10.4.1
+  export PATH="/tmp/npm-global/bin:${PATH}"
+  (
+    cd /tmp/Vencord
+    pnpm install --frozen-lockfile
+    pnpm build
+    install -Dm0644 dist/patcher.js /usr/share/vencord/patcher.js
+    install -Dm0644 dist/preload.js /usr/share/vencord/preload.js
+    install -Dm0644 dist/renderer.js /usr/share/vencord/renderer.js
+    install -Dm0644 dist/renderer.css /usr/share/vencord/renderer.css
+  )
 
-node /usr/local/bin/patch-discord-vencord-asar.mjs
-test -f /usr/share/discord/resources/_app.asar
-test -f /usr/share/discord/resources/app.asar
-grep -aqF '/usr/share/vencord/patcher.js' /usr/share/discord/resources/app.asar
-test -f /usr/share/vencord/patcher.js
-test -f /usr/share/vencord/preload.js
-test -f /usr/share/vencord/renderer.js
-test -f /usr/share/vencord/renderer.css
+  node /usr/local/bin/patch-discord-vencord-asar.mjs
+  test -f /usr/share/discord/resources/_app.asar
+  test -f /usr/share/discord/resources/app.asar
+  grep -aqF '/usr/share/vencord/patcher.js' /usr/share/discord/resources/app.asar
+  test -f /usr/share/vencord/patcher.js
+  test -f /usr/share/vencord/preload.js
+  test -f /usr/share/vencord/renderer.js
+  test -f /usr/share/vencord/renderer.css
+else
+  echo "Discord package does not include resources/app.asar; skipping image-level Vencord patch"
+fi
 
 # Enable the KDE idle sync watcher for all users by default.
 mkdir -p /usr/lib/systemd/user/graphical-session.target.wants

--- a/build.sh
+++ b/build.sh
@@ -55,7 +55,9 @@ mkdir -p /usr/share/discord
 tar -xzf /tmp/discord.tar.gz --strip-components=1 -C /usr/share/discord
 ln -sf /usr/share/discord/Discord /usr/bin/discord
 install -Dm0644 /usr/share/discord/discord.desktop /usr/share/applications/discord.desktop
-chmod 4755 /usr/share/discord/chrome-sandbox
+if [[ -e /usr/share/discord/chrome-sandbox ]]; then
+  chmod 4755 /usr/share/discord/chrome-sandbox
+fi
 
 # Discord's RPM desktop file uses Icon=discord but does not install that icon
 # into the theme search path. Provide a stable hicolor entry when Discord exists.


### PR DESCRIPTION
## Summary

- link whichever Discord executable the official package ships (`Discord` or `discord`)
- make the Discord `chrome-sandbox` chmod conditional
- run the image-level Vencord `app.asar` patch only when Discord includes `resources/app.asar`
- skip that patch cleanly for the current official bootstrap-only Linux package layout

## Root Cause

The post-merge image build failed because the official Discord Linux package changed shape. It currently contains the bootstrap launcher, desktop file, icon, and post-install script, but it no longer includes `chrome-sandbox` or `resources/app.asar`. The old build assumed both files existed and failed first at `chmod`, then at the Vencord asar patcher.

## Validation

- `bash -n build.sh`
- `git diff --check`
- downloaded the current official Discord tarball and verified it contains `Discord/discord` and `Discord/discord.desktop`, but no `chrome-sandbox` or `resources/app.asar`

Merging this should trigger the existing `push` workflow on `main`, which publishes the corrected image tags (`latest`, `latest.YYYYMMDD`, and `YYYYMMDD`). A separate GitHub release is not needed for this workflow unless you specifically want a GitHub Releases entry.