### PR TITLE
[codex] Use official Discord RPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A [Fedora Atomic](https://fedoraproject.org/atomic-desktops) image built with [U
 - Preinstalls Piper for configuring mice.
 - Preinstalls CoreCtrl for power management.
 - Adds an Open With action in Dolphin to encode videos for Discord using CPU H.264 with a target-size popup and progress bar.
-- Installs Discord from the official tarball at image build time, patches it with a pinned Vencord build, and includes a KDE idle/lock watcher that can drive Discord presence over a local socket.
+- Installs Discord from the official RPM at image build time, patches it with a pinned Vencord build when app resources are available, and includes a KDE idle/lock watcher that can drive Discord presence over a local socket.
 - Includes a KDE user service that automatically reapplies the right HDR display configuration after a KVM reconnect on the default dual-monitor setup.
 
 ## How to use

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 VENCORD_REF="cba0eb9897419432e68277b0b60c301a6f8323cf"
 VENCORD_TAG="v1.14.6"
+DISCORD_RPM_URL="https://discord.com/api/download?platform=linux&format=rpm"
 
 ###############################################################################
 # Directories that must exist during the RPM unpack phase
@@ -47,21 +48,17 @@ dnf5 install -y \
   oxygen-icon-theme
 
 ###############################################################################
-# Install Discord at image level (official tarball)
+# Install Discord at image level (official RPM)
 ###############################################################################
-curl -L 'https://discord.com/api/download?platform=linux&format=tar.gz' \
-  -o /tmp/discord.tar.gz
-mkdir -p /usr/share/discord
-tar -xzf /tmp/discord.tar.gz --strip-components=1 -C /usr/share/discord
-if [[ -x /usr/share/discord/Discord ]]; then
-  ln -sf /usr/share/discord/Discord /usr/bin/discord
-elif [[ -x /usr/share/discord/discord ]]; then
-  ln -sf /usr/share/discord/discord /usr/bin/discord
+curl -fL "${DISCORD_RPM_URL}" -o /tmp/discord.rpm
+dnf5 install -y /tmp/discord.rpm
+rm -f /tmp/discord.rpm
+if [[ -x /usr/bin/discord ]]; then
+  :
 else
-  echo "Discord executable not found in official tarball" >&2
+  echo "Discord executable not found after installing official RPM" >&2
   exit 1
 fi
-install -Dm0644 /usr/share/discord/discord.desktop /usr/share/applications/discord.desktop
 if [[ -e /usr/share/discord/chrome-sandbox ]]; then
   chmod 4755 /usr/share/discord/chrome-sandbox
 fi


### PR DESCRIPTION
## Summary
- Replace the manual Discord Linux tarball extraction with Discord's official Linux RPM endpoint.
- Keep the image-level Discord executable check and update README wording for the RPM install path.

## Impact
This moves James OS to Discord's native RPM/Fedora packaging now that Discord publishes an official RPM. The Vencord patch step remains conditional because the new official RPM installs Discord's updater bootstrap rather than always shipping app resources in the package payload.

## Validation
- `bash -n build.sh`
- `git diff --check -- build.sh README.md`
- Verified Discord's RPM endpoint redirects to `discord-1.0.138.rpm` and serves `application/x-redhat-package-manager`.
