### PR TITLE
[codex] Fix Discord VA-API encode launcher

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -59,6 +59,65 @@ else
   echo "Discord executable not found after installing official RPM" >&2
   exit 1
 fi
+cat > /usr/bin/discord <<'EOF'
+#!/bin/sh
+
+CHANNEL=stable
+DOWNLOAD=https://updates.discord.com/
+DIR=discord
+EXE=Discord
+BOOTSTRAP_SUFFIX=discord/updater_bootstrap
+
+config_home=$XDG_CONFIG_HOME
+if [ -z "$config_home" ]; then
+    config_home=$HOME/.config
+fi
+
+discord_host=$config_home/$DIR/$EXE
+
+apply_discord_vaapi_fixes() {
+    for voice_dir in "$config_home"/$DIR/[0-9]*.[0-9]*.[0-9]*/modules/discord_voice; do
+        [ -d "$voice_dir" ] || continue
+        chmod u+x "$voice_dir/gpu_encoder_helper" "$voice_dir/discord_voice.node" 2>/dev/null || true
+    done
+}
+
+discord_flags="--enable-features=VaapiVideoDecoder,VaapiVideoEncoder,AcceleratedVideoEncoder --ignore-gpu-blocklist"
+
+if [ ! -x "$discord_host" ]; then
+    mkdir -p "$config_home/$DIR"
+    if [ ! -d "$config_home/$DIR" ]; then
+        echo "Fatal error, failed to create $DIR in $config_home" >&2
+        exit 1
+    fi
+    if [ -t 1 ]; then
+        zenity=--no-zenity
+    else
+        zenity=--zenity
+    fi
+    bootstrap=/usr/share/$BOOTSTRAP_SUFFIX
+    if [ ! -x "$bootstrap" ]; then
+        bootstrap=/opt/$BOOTSTRAP_SUFFIX
+        if [ ! -x "$bootstrap" ]; then
+            bootstrap=`dirname -- "$0"`/updater_bootstrap
+        fi
+    fi
+    app_dir=`"$bootstrap" $zenity "$config_home/$DIR" $CHANNEL "$DOWNLOAD"`
+
+    if [ $? -eq 0 ] ; then
+        echo "Bootstrap complete"
+        apply_discord_vaapi_fixes
+        exec "$config_home/$DIR/$app_dir/$EXE" $discord_flags "$@"
+    else
+        echo "Bootstrap failed or was canceled"
+        exit 2
+    fi
+fi
+
+apply_discord_vaapi_fixes
+exec "$discord_host" $discord_flags "$@"
+EOF
+chmod 0755 /usr/bin/discord
 if [[ -e /usr/share/discord/chrome-sandbox ]]; then
   chmod 4755 /usr/share/discord/chrome-sandbox
 fi


### PR DESCRIPTION
## Summary

This updates the image-level Discord launcher installed by the official RPM so Discord can use AMD VA-API hardware encoding for screenshare.

The launcher now reapplies executable permissions to Discord's per-user `discord_voice` helper binaries on every start, then launches Discord with the VA-API video encoder flags enabled.

## Root Cause

On the live system, Discord's WebRTC logs showed the GPU encoder probe failing before it could query VA-API:

```text
Failed to probe Amd: Failed to spawn helper process: Permission denied
```

The per-user `gpu_encoder_helper` was installed without the executable bit, so Discord reported H.264 encode support as unavailable and fell back to VP8 software encoding. After fixing permissions and launching with VA-API encode flags, Discord reported `H264 (amd: vaapi)` and the AMD encode engine counter advanced during screenshare.

## Validation

- `bash -n build.sh`
- Extracted the generated `/usr/bin/discord` heredoc and ran `sh -n` on it
- `git diff --check -- build.sh`
