### PR TITLE
[codex] Disable Discord Flatpak RPC bridge cleanup

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -63,6 +63,15 @@ if [[ -e /usr/share/discord/chrome-sandbox ]]; then
   chmod 4755 /usr/share/discord/chrome-sandbox
 fi
 
+# Drop the legacy Discord Flatpak RPC bridge if it is present from an older
+# image or layer. This image installs the native Discord RPM, and the bridge can
+# proxy its own socket into itself when no Flatpak Discord process owns the
+# target, flooding journald and burning CPU.
+rm -f \
+  /etc/systemd/user/sockets.target.wants/discord-flatpak-rpc-bridge.socket \
+  /etc/systemd/user/discord-flatpak-rpc-bridge.socket \
+  /etc/systemd/user/discord-flatpak-rpc-bridge.service
+
 # Discord's RPM desktop file uses Icon=discord but does not install that icon
 # into the theme search path. Provide a stable hicolor entry when Discord exists.
 mkdir -p /usr/share/icons/hicolor/256x256/apps


### PR DESCRIPTION
## Summary
- remove the legacy Discord Flatpak RPC bridge socket/service files during image build
- remove the global socket enablement symlink if it exists from an older image layer

## Why
The workstation freeze investigation found `discord-flatpak-rpc-bridge.service` proxying `/run/user/1000/discord-ipc-0` back into its own Flatpak compatibility socket. With no Discord Flatpak process owning the target, `systemd-socket-proxyd` looped on `Too many open files`, flooded journald, and burned CPU.

This image now installs the native Discord RPM, so the Flatpak RPC bridge is stale and should not be globally enabled.

## Validation
- `bash -n build.sh`
- `git diff --check -- build.sh`
