### PR TITLE
Fix Codex Desktop Topgrade updates

### DIFF
--- a/system/usr_local_bin__topgrade-codex-desktop-linux-update
+++ b/system/usr_local_bin__topgrade-codex-desktop-linux-update
@@ -107,6 +107,7 @@ running_app_pid() {
 
 collect_running_pids() {
     local electron_path
+    local electron_pid
     local start_path
     local webview_path
     local proc_dir
@@ -115,6 +116,7 @@ collect_running_pids() {
     local cmdline
 
     electron_path="$(realpath -m "$APP_DIR/electron")"
+    electron_pid="$(running_app_pid || true)"
     start_path="$(realpath -m "$APP_DIR/start.sh")"
     webview_path="$(realpath -m "$APP_DIR/.codex-linux/webview-server.py")"
 
@@ -129,11 +131,33 @@ collect_running_pids() {
         cmdline="$(tr '\0' ' ' < "$proc_dir/cmdline" 2>/dev/null || true)"
 
         case "$actual:$cmdline" in
-            "$electron_path":*|*"$start_path"*|*"$webview_path"*|*"codex app-server --analytics-default-enabled"*)
+            "$electron_path":*|*"$start_path"*|*"$webview_path"*)
                 echo "$pid"
                 ;;
         esac
+
+        if [ -n "$electron_pid" ] \
+            && [ "$pid" != "$electron_pid" ] \
+            && is_descendant_of "$pid" "$electron_pid" \
+            && [[ "$cmdline" == *"codex app-server --analytics-default-enabled"* ]]; then
+            echo "$pid"
+        fi
     done | sort -n -u
+}
+
+is_descendant_of() {
+    local pid="$1"
+    local ancestor="$2"
+    local parent
+
+    while [ -n "$pid" ] && [ "$pid" != "0" ] && [ -r "/proc/$pid/status" ]; do
+        [ "$pid" != "$ancestor" ] || return 0
+        parent="$(awk '/^PPid:/ { print $2; exit }' "/proc/$pid/status" 2>/dev/null || true)"
+        [ -n "$parent" ] || return 1
+        pid="$parent"
+    done
+
+    return 1
 }
 
 stop_running_app() {
@@ -174,13 +198,8 @@ restart_app_if_needed() {
 
     echo "Restarting Codex Desktop..."
     nohup "$APP_DIR/start.sh" >/dev/null 2>&1 &
+    restart_after_update=0
 }
-
-restart_after_update=0
-if running_app_pid >/dev/null; then
-    restart_after_update=1
-    stop_running_app
-fi
 
 old_head="$(git -C "$REPO_DIR" rev-parse HEAD)"
 git -C "$REPO_DIR" pull --ff-only
@@ -193,6 +212,13 @@ fi
 write_install_env
 patch_installed_common
 
+restart_after_update=0
+if running_app_pid >/dev/null; then
+    restart_after_update=1
+    stop_running_app
+    trap restart_app_if_needed EXIT
+fi
+
 if pid="$(running_app_pid)"; then
     echo "Codex Desktop is still running from $APP_DIR (pid $pid); cannot update safely." >&2
     exit 1
@@ -200,9 +226,7 @@ fi
 
 if [ "$old_head" != "$new_head" ]; then
     "$HOME/.local/bin/codex-desktop-update" --force
-    restart_app_if_needed
     exit 0
 fi
 
 "$HOME/.local/bin/codex-desktop-update"
-restart_app_if_needed

--- a/system/usr_local_bin__topgrade-codex-desktop-linux-update
+++ b/system/usr_local_bin__topgrade-codex-desktop-linux-update
@@ -105,6 +105,83 @@ running_app_pid() {
     return 1
 }
 
+collect_running_pids() {
+    local electron_path
+    local start_path
+    local webview_path
+    local proc_dir
+    local pid
+    local actual
+    local cmdline
+
+    electron_path="$(realpath -m "$APP_DIR/electron")"
+    start_path="$(realpath -m "$APP_DIR/start.sh")"
+    webview_path="$(realpath -m "$APP_DIR/.codex-linux/webview-server.py")"
+
+    for proc_dir in /proc/[0-9]*; do
+        [ -d "$proc_dir" ] || continue
+        pid="${proc_dir#/proc/}"
+        [ "$pid" != "$$" ] || continue
+
+        actual="$(readlink -f "$proc_dir/exe" 2>/dev/null || true)"
+        [ -n "$actual" ] && actual="$(realpath -m "$actual")"
+
+        cmdline="$(tr '\0' ' ' < "$proc_dir/cmdline" 2>/dev/null || true)"
+
+        case "$actual:$cmdline" in
+            "$electron_path":*|*"$start_path"*|*"$webview_path"*|*"codex app-server --analytics-default-enabled"*)
+                echo "$pid"
+                ;;
+        esac
+    done | sort -n -u
+}
+
+stop_running_app() {
+    local pids
+    local pid
+    local deadline
+    local remaining
+
+    pids="$(collect_running_pids)"
+    [ -n "$pids" ] || return 0
+
+    echo "Stopping Codex Desktop before updating..."
+    while IFS= read -r pid; do
+        [ -n "$pid" ] || continue
+        kill -TERM "$pid" 2>/dev/null || true
+    done <<< "$pids"
+
+    deadline=$((SECONDS + 15))
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        remaining="$(collect_running_pids)"
+        [ -z "$remaining" ] && return 0
+        sleep 0.5
+    done
+
+    remaining="$(collect_running_pids)"
+    if [ -n "$remaining" ]; then
+        echo "Codex Desktop did not exit after SIGTERM; forcing remaining processes: ${remaining//$'\n'/ }"
+        while IFS= read -r pid; do
+            [ -n "$pid" ] || continue
+            kill -KILL "$pid" 2>/dev/null || true
+        done <<< "$remaining"
+    fi
+}
+
+restart_app_if_needed() {
+    [ "${restart_after_update:-0}" -eq 1 ] || return 0
+    [ -x "$APP_DIR/start.sh" ] || return 0
+
+    echo "Restarting Codex Desktop..."
+    nohup "$APP_DIR/start.sh" >/dev/null 2>&1 &
+}
+
+restart_after_update=0
+if running_app_pid >/dev/null; then
+    restart_after_update=1
+    stop_running_app
+fi
+
 old_head="$(git -C "$REPO_DIR" rev-parse HEAD)"
 git -C "$REPO_DIR" pull --ff-only
 new_head="$(git -C "$REPO_DIR" rev-parse HEAD)"
@@ -117,13 +194,15 @@ write_install_env
 patch_installed_common
 
 if pid="$(running_app_pid)"; then
-    echo "Codex Desktop is running from $APP_DIR (pid $pid); skipping rebuild."
-    echo "Close Codex Desktop and rerun System Update to apply Codex Desktop updates."
-    exit 0
+    echo "Codex Desktop is still running from $APP_DIR (pid $pid); cannot update safely." >&2
+    exit 1
 fi
 
 if [ "$old_head" != "$new_head" ]; then
-    exec "$HOME/.local/bin/codex-desktop-update" --force
+    "$HOME/.local/bin/codex-desktop-update" --force
+    restart_app_if_needed
+    exit 0
 fi
 
-exec "$HOME/.local/bin/codex-desktop-update"
+"$HOME/.local/bin/codex-desktop-update"
+restart_app_if_needed


### PR DESCRIPTION
## Summary
- stop the running Codex Desktop process tree before the Topgrade custom update rebuilds it
- fail the Topgrade command if Codex Desktop is still running after the stop attempt instead of reporting a false success
- restart Codex Desktop after a successful update when it was running beforehand

## Validation
- `bash -n system/usr_local_bin__topgrade-codex-desktop-linux-update`
- validated the same local hook behavior on the workstation: the update completed end to end after the desktop process was no longer allowed to silently skip the rebuild

Note: the local validation also exposed and fixed a separate `codex-desktop-linux` wrapper patch drift for the current Electron 42.1.0 bundle in the local checkout; this PR carries the image-level Topgrade hook fix.