### PR TITLE
[codex] Remove stale Discord Flatpak RPC bridge paths

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -145,9 +145,16 @@ fi
 # proxy its own socket into itself when no Flatpak Discord process owns the
 # target, flooding journald and burning CPU.
 rm -f \
+  /etc/systemd/user/default.target.wants/discord-flatpak-rpc-bridge.service \
+  /etc/systemd/user/default.target.wants/discord-flatpak-rpc-bridge.socket \
   /etc/systemd/user/sockets.target.wants/discord-flatpak-rpc-bridge.socket \
   /etc/systemd/user/discord-flatpak-rpc-bridge.socket \
-  /etc/systemd/user/discord-flatpak-rpc-bridge.service
+  /etc/systemd/user/discord-flatpak-rpc-bridge.service \
+  /usr/lib/systemd/user/default.target.wants/discord-flatpak-rpc-bridge.service \
+  /usr/lib/systemd/user/default.target.wants/discord-flatpak-rpc-bridge.socket \
+  /usr/lib/systemd/user/sockets.target.wants/discord-flatpak-rpc-bridge.socket \
+  /usr/lib/systemd/user/discord-flatpak-rpc-bridge.socket \
+  /usr/lib/systemd/user/discord-flatpak-rpc-bridge.service
 
 # Discord's RPM desktop file uses Icon=discord but does not install that icon
 # into the theme search path. Provide a stable hicolor entry when Discord exists.


### PR DESCRIPTION
## Summary
- expand the Discord Flatpak RPC bridge cleanup to remove stale user unit files from both /etc and /usr/lib systemd user-unit locations
- remove default.target and sockets.target enablement links when present

## Why
The bridge can proxy its own Discord IPC socket into itself when no Flatpak Discord process owns the target. On the workstation this caused systemd-socket-proxyd to flood journald with `Too many open files` and burn CPU. The image now uses the native Discord RPM path, so any remaining Flatpak bridge units should be removed wherever they are layered.

## Validation
- `bash -n build.sh`

## Live host note
I stopped the active user service and socket. A global disable on the current machine still requires sudo because the enablement link lives under `/etc/systemd/user`. This PR covers the image cleanup path.