### PR TITLE
[codex] Fix 1Password MCP integration groups

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -257,15 +257,41 @@ done
 # Helper & CLI binaries need dedicated groups + setgid
 chgrp ${GID_ONEPASSWORD} /usr/lib/1Password/1Password-BrowserSupport
 chmod g+s               /usr/lib/1Password/1Password-BrowserSupport
+chgrp ${GID_ONEPASSWORD} /usr/lib/1Password/onepassword-mcp
+chmod g+s               /usr/lib/1Password/onepassword-mcp
 
 chgrp ${GID_ONEPASSWORDCLI} /usr/bin/op
 chmod g+s                 /usr/bin/op
 
 # sysusers file – creates groups (once) at boot
 cat > /usr/lib/sysusers.d/onepassword.conf <<EOF
-g onepassword     ${GID_ONEPASSWORD}     "1Password application group"
-g onepassword-cli ${GID_ONEPASSWORDCLI}  "1Password CLI group"
+g onepassword     ${GID_ONEPASSWORD}
+g onepassword-cli ${GID_ONEPASSWORDCLI}
 EOF
+
+# Ensure upgraded ostree deployments materialize these groups in /etc/group.
+# systemd-sysusers.service is conditional on /etc needing an update, which can
+# skip new sysusers snippets on already-installed systems.
+cat > /usr/lib/systemd/system/james-os-1password-groups.service <<'EOF'
+[Unit]
+Description=Ensure 1Password integration groups exist
+Documentation=man:sysusers.d(5) man:systemd-sysusers(8)
+DefaultDependencies=no
+After=systemd-remount-fs.service
+Before=sysinit.target
+ConditionPathExists=/usr/lib/sysusers.d/onepassword.conf
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/systemd-sysusers /usr/lib/sysusers.d/onepassword.conf
+
+[Install]
+WantedBy=sysinit.target
+EOF
+
+mkdir -p /usr/lib/systemd/system/sysinit.target.wants
+ln -sfn ../james-os-1password-groups.service \
+  /usr/lib/systemd/system/sysinit.target.wants/james-os-1password-groups.service
 
 # tmpfiles rule – recreates /opt/1Password symlink on every boot
 cat > /usr/lib/tmpfiles.d/onepassword.conf <<'EOF'


### PR DESCRIPTION
## Summary
- assign `onepassword-mcp` to the same setgid application group as `1Password-BrowserSupport`
- fix the generated `onepassword.conf` sysusers syntax so the groups can actually be created
- add a small sysinit oneshot to run only the 1Password sysusers file on upgraded ostree deployments

## Root Cause
1Password's Linux app integration validates peer process credentials. The live system had `onepassword-mcp` owned by an unrelated group, and the expected `onepassword` / `onepassword-cli` groups were not present in `/etc/group`. The generated sysusers file used GECOS fields on `g` lines, which systemd warns are invalid, and the standard `systemd-sysusers.service` is conditional on `/etc` needing an update, so it is not reliable as the only repair path for already-installed ostree deployments.

## Validation
- `bash -n build.sh`
- `systemd-sysusers --dry-run --inline 'g onepassword 1500' 'g onepassword-cli 1600'`
- `systemd-analyze verify` against the generated `james-os-1password-groups.service` contents
