### PR TITLE
[codex] Restore Discord native Wayland and unblock image builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -82,7 +82,7 @@ apply_discord_runtime_fixes() {
     done
 }
 
-discord_flags="--ozone-platform=wayland --enable-features=UseOzonePlatform,WaylandWindowDecorations --ignore-gpu-blocklist --enable-gpu-rasterization --enable-zero-copy --disable-vulkan"
+discord_flags="--ozone-platform=wayland --disable-vulkan"
 
 if [ ! -x "$discord_host" ]; then
     mkdir -p "$config_home/$DIR"
@@ -257,8 +257,25 @@ done
 # Helper & CLI binaries need dedicated groups + setgid
 chgrp ${GID_ONEPASSWORD} /usr/lib/1Password/1Password-BrowserSupport
 chmod g+s               /usr/lib/1Password/1Password-BrowserSupport
-chgrp ${GID_ONEPASSWORD} /usr/lib/1Password/onepassword-mcp
-chmod g+s               /usr/lib/1Password/onepassword-mcp
+
+ONEPASSWORD_MCP_BIN=""
+for candidate in \
+  /usr/lib/1Password/1password-mcp \
+  /usr/lib/1Password/onepassword-mcp
+do
+  if [[ -x "${candidate}" ]]; then
+    ONEPASSWORD_MCP_BIN="${candidate}"
+    break
+  fi
+done
+
+if [[ -z "${ONEPASSWORD_MCP_BIN}" ]]; then
+  echo "1Password MCP executable not found at a supported path" >&2
+  exit 1
+fi
+
+chgrp ${GID_ONEPASSWORD} "${ONEPASSWORD_MCP_BIN}"
+chmod g+s               "${ONEPASSWORD_MCP_BIN}"
 
 chgrp ${GID_ONEPASSWORDCLI} /usr/bin/op
 chmod g+s                 /usr/bin/op


### PR DESCRIPTION
## Summary

- keep Discord on native Wayland while removing the forced GPU blocklist, rasterization, zero-copy, and redundant Ozone feature overrides
- retain only `--ozone-platform=wayland --disable-vulkan`
- support both the renamed `1password-mcp` binary and its legacy `onepassword-mcp` path

## Root cause

The desktop's custom Vencord launcher bypassed `/usr/bin/discord`, pinning Discord host `0.0.130` with host updates disabled. Its forced Wayland GPU flags (`--ignore-gpu-blocklist --enable-gpu-rasterization --enable-zero-copy`) produced renderer hangs, exit-139 crashes, and eventually dead pointer input.

A clean official bootstrap installed current host `1.0.149`. It ran on native Wayland with only `--ozone-platform=wayland --disable-vulkan`, authenticated, connected to the gateway, and accepted UI navigation without a restart, coredump, renderer crash, or unresponsive event. The image already uses the official updater bootstrap; this PR removes the aggressive flags that made that path unsafe.

Separately, 1Password 8.12.28 renamed its MCP executable to `1password-mcp`. The hardcoded legacy path caused the July 15 and July 16 image builds to fail, which would prevent this fix from being published.

## User impact

Discord remains native Wayland, stays on the official updater-managed host, and no longer forces unstable GPU behavior. The live desktop retains its old Vencord installation only as a rollback backup.

## Validation

- `bash -n build.sh`
- extracted generated `/usr/bin/discord` launcher passed `sh -n`
- `git diff --check`
- isolated official Discord 1.0.149 native Wayland test loaded the signed-in UI and accepted channel navigation
- zero restarts and no new renderer crash/unresponsive events during the native test

`just` and `shellcheck` were not installed in the local environment.