### PR TITLE
[codex] Use a managed canonical Codex Desktop source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
+      - name: Test Codex Desktop managed source
+        run: bash tests/test-topgrade-codex-desktop-linux-update.sh
+
       # This is required for large images like bazzite-dx to prevent "no space left on device" errors
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@cc0becac701cf642c8f0a6613bbdaf5dc36b259e # v9

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A [Fedora Atomic](https://fedoraproject.org/atomic-desktops) image built with [U
 - Removes Lutris.
 - Preinstalls 1Password and the 1Password CLI.
 - Adds back Konsole as a terminal option and Yakuake to complement it (ptyxis remains the default for compatibility with some Bazzite features).
-- Launches the System Update shortcut in Konsole and includes a Topgrade custom step for a local `codex-desktop-linux` checkout.
+- Launches the System Update shortcut in Konsole and includes a Topgrade custom step backed by a managed clone of the canonical `codex-desktop-linux` repository. Set `CODEX_DESKTOP_LINUX_REPO` to explicitly use a clean, non-diverged canonical checkout instead.
 - Preinstalls Piper for configuring mice.
 - Preinstalls CoreCtrl for power management.
 - Adds an Open With action in Dolphin to encode videos for Discord using CPU H.264 with a target-size popup and progress bar.

--- a/system/usr_local_bin__topgrade-codex-desktop-linux-update
+++ b/system/usr_local_bin__topgrade-codex-desktop-linux-update
@@ -1,39 +1,167 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo_candidates=(
-    "${CODEX_DESKTOP_LINUX_REPO:-}"
-    "${HOME}/codex-desktop-linux"
-    "${HOME}/Projects/codex-desktop-linux"
-    "${HOME}/workspace/codex-desktop-linux"
-)
-
-REPO_DIR=""
-for candidate in "${repo_candidates[@]}"; do
-    if [ -n "$candidate" ] && [ -d "$candidate/.git" ]; then
-        REPO_DIR="$candidate"
-        break
-    fi
-done
-
-if [ -z "$REPO_DIR" ]; then
-    echo "codex-desktop-linux checkout not found; set CODEX_DESKTOP_LINUX_REPO." >&2
-    exit 1
-fi
-
+CANONICAL_REPO_URL="https://github.com/ilysenko/codex-desktop-linux.git"
+CANONICAL_DEFAULT_BRANCH="main"
+DATA_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}"
+MANAGED_REPO_DIR="${DATA_HOME}/codex-desktop-linux/managed-repo"
 OPT_ROOT="${HOME}/.local/opt/codex-desktop-linux"
 APP_DIR="${OPT_ROOT}/codex-app"
 STATE_DIR="${XDG_STATE_HOME:-${HOME}/.local/state}/codex-desktop-linux"
 INSTALL_ENV="${STATE_DIR}/install.env"
-DMG_FILE="${REPO_DIR}/Codex.dmg"
+REPO_DIR=""
+DMG_FILE=""
+SOURCE_MODE=""
+SOURCE_OLD_HEAD=""
+SOURCE_NEW_HEAD=""
 
 # Avoid interactive npx package-install prompts during unattended Topgrade runs.
 export npm_config_yes=true
+
+fail() {
+    echo "topgrade-codex-desktop-linux-update: $*" >&2
+    exit 1
+}
+
+normalize_repo_url() {
+    local url="$1"
+
+    url="${url%/}"
+    url="${url%.git}"
+    case "$url" in
+        git@github.com:*)
+            url="https://github.com/${url#git@github.com:}"
+            ;;
+        ssh://git@github.com/*)
+            url="https://github.com/${url#ssh://git@github.com/}"
+            ;;
+    esac
+
+    printf '%s\n' "$url" | tr '[:upper:]' '[:lower:]'
+}
+
+is_git_checkout() {
+    local repo_dir="$1"
+    [ -d "$repo_dir" ] \
+        && [ "$(git -C "$repo_dir" rev-parse --is-inside-work-tree 2>/dev/null || true)" = "true" ]
+}
+
+validate_repo_origin() {
+    local repo_dir="$1"
+    local origin_url
+
+    origin_url="$(git -C "$repo_dir" remote get-url origin 2>/dev/null || true)"
+    [ -n "$origin_url" ] || fail "checkout has no origin remote: $repo_dir"
+
+    if [ "$(normalize_repo_url "$origin_url")" != "$(normalize_repo_url "$CANONICAL_REPO_URL")" ]; then
+        fail "checkout origin is not the canonical source: $repo_dir"
+    fi
+}
+
+ensure_managed_origin() {
+    local origin_url
+
+    origin_url="$(git -C "$MANAGED_REPO_DIR" remote get-url origin 2>/dev/null || true)"
+    if [ -z "$origin_url" ]; then
+        echo "Configuring canonical origin for the managed Codex Desktop source..."
+        git -C "$MANAGED_REPO_DIR" remote add origin "$CANONICAL_REPO_URL"
+    elif [ "$(normalize_repo_url "$origin_url")" != "$(normalize_repo_url "$CANONICAL_REPO_URL")" ]; then
+        echo "Repointing the managed Codex Desktop source to its canonical origin..."
+        git -C "$MANAGED_REPO_DIR" remote set-url origin "$CANONICAL_REPO_URL"
+    fi
+
+    git -C "$MANAGED_REPO_DIR" config --replace-all \
+        remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+}
+
+select_source_repo() {
+    if [ -n "${CODEX_DESKTOP_LINUX_REPO:-}" ]; then
+        REPO_DIR="${CODEX_DESKTOP_LINUX_REPO}"
+        SOURCE_MODE="explicit"
+    else
+        REPO_DIR="$MANAGED_REPO_DIR"
+        SOURCE_MODE="managed"
+    fi
+    DMG_FILE="${REPO_DIR}/Codex.dmg"
+}
+
+clone_managed_repo() {
+    mkdir -p "$(dirname "$MANAGED_REPO_DIR")"
+    git clone \
+        --origin origin \
+        --branch "$CANONICAL_DEFAULT_BRANCH" \
+        --single-branch \
+        "$CANONICAL_REPO_URL" \
+        "$MANAGED_REPO_DIR"
+}
+
+fetch_source_repo() {
+    git -C "$REPO_DIR" fetch --prune origin
+}
+
+prepare_source_repo() {
+    local canonical_ref="origin/${CANONICAL_DEFAULT_BRANCH}"
+    local ahead
+    local behind
+    local counts
+    local dirty
+
+    select_source_repo
+
+    if [ "$SOURCE_MODE" = "explicit" ]; then
+        is_git_checkout "$REPO_DIR" || fail "CODEX_DESKTOP_LINUX_REPO is not a Git checkout: $REPO_DIR"
+        validate_repo_origin "$REPO_DIR"
+
+        dirty="$(git -C "$REPO_DIR" status --porcelain --untracked-files=normal)"
+        if [ -n "$dirty" ]; then
+            fail "CODEX_DESKTOP_LINUX_REPO is dirty; refusing to modify it: $REPO_DIR"
+        fi
+        SOURCE_OLD_HEAD="$(git -C "$REPO_DIR" rev-parse HEAD)"
+    else
+        if [ -e "$REPO_DIR" ] && ! is_git_checkout "$REPO_DIR"; then
+            fail "managed source path exists but is not a Git checkout: $REPO_DIR"
+        fi
+        if ! is_git_checkout "$REPO_DIR"; then
+            clone_managed_repo
+            SOURCE_OLD_HEAD=""
+        else
+            SOURCE_OLD_HEAD="$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null || true)"
+        fi
+        ensure_managed_origin
+    fi
+
+    fetch_source_repo
+    git -C "$REPO_DIR" rev-parse --verify --quiet "$canonical_ref" >/dev/null \
+        || fail "canonical branch is unavailable after fetch: $canonical_ref"
+
+    if [ "$SOURCE_MODE" = "explicit" ]; then
+        counts="$(git -C "$REPO_DIR" rev-list --left-right --count "HEAD...${canonical_ref}")"
+        read -r ahead behind <<<"$counts"
+        if [ "$ahead" -ne 0 ]; then
+            fail "CODEX_DESKTOP_LINUX_REPO has local or diverged commits; refusing to modify it: $REPO_DIR"
+        fi
+        git -C "$REPO_DIR" merge --ff-only "$canonical_ref"
+    else
+        # This checkout is dedicated to the updater, so converge tracked files
+        # to the canonical branch instead of inheriting local source drift.
+        git -C "$REPO_DIR" reset --hard "$canonical_ref"
+    fi
+
+    if [ ! -x "$REPO_DIR/contrib/user-local-install/install-user-local.sh" ]; then
+        fail "canonical checkout is missing the user-local installer: $REPO_DIR"
+    fi
+
+    SOURCE_NEW_HEAD="$(git -C "$REPO_DIR" rev-parse HEAD)"
+}
 
 write_install_env() {
     mkdir -p "$STATE_DIR"
     {
         printf 'REPO_DIR=%q\n' "$REPO_DIR"
+        printf 'SOURCE_REPO_DIR=%q\n' "$REPO_DIR"
+        printf 'MANAGED_REPO_DIR=%q\n' "$MANAGED_REPO_DIR"
+        printf 'REPO_ORIGIN_URL=%q\n' "$CANONICAL_REPO_URL"
+        printf 'REPO_DEFAULT_BRANCH=%q\n' "$CANONICAL_DEFAULT_BRANCH"
         printf 'OPT_ROOT=%q\n' "$OPT_ROOT"
         printf 'APP_DIR=%q\n' "$APP_DIR"
         printf 'DMG_FILE=%q\n' "$DMG_FILE"
@@ -201,32 +329,35 @@ restart_app_if_needed() {
     restart_after_update=0
 }
 
-old_head="$(git -C "$REPO_DIR" rev-parse HEAD)"
-git -C "$REPO_DIR" pull --ff-only
-new_head="$(git -C "$REPO_DIR" rev-parse HEAD)"
+main() {
+    local pid
 
-if [ -x "$REPO_DIR/contrib/user-local-install/install-user-local.sh" ]; then
+    prepare_source_repo
     "$REPO_DIR/contrib/user-local-install/install-user-local.sh" --from-update
+
+    write_install_env
+    patch_installed_common
+
+    restart_after_update=0
+    if running_app_pid >/dev/null; then
+        restart_after_update=1
+        stop_running_app
+        trap restart_app_if_needed EXIT
+    fi
+
+    if pid="$(running_app_pid)"; then
+        echo "Codex Desktop is still running from $APP_DIR (pid $pid); cannot update safely." >&2
+        exit 1
+    fi
+
+    if [ "$SOURCE_OLD_HEAD" != "$SOURCE_NEW_HEAD" ]; then
+        "$HOME/.local/bin/codex-desktop-update" --force
+        exit 0
+    fi
+
+    "$HOME/.local/bin/codex-desktop-update"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
 fi
-
-write_install_env
-patch_installed_common
-
-restart_after_update=0
-if running_app_pid >/dev/null; then
-    restart_after_update=1
-    stop_running_app
-    trap restart_app_if_needed EXIT
-fi
-
-if pid="$(running_app_pid)"; then
-    echo "Codex Desktop is still running from $APP_DIR (pid $pid); cannot update safely." >&2
-    exit 1
-fi
-
-if [ "$old_head" != "$new_head" ]; then
-    "$HOME/.local/bin/codex-desktop-update" --force
-    exit 0
-fi
-
-"$HOME/.local/bin/codex-desktop-update"

--- a/tests/test-topgrade-codex-desktop-linux-update.sh
+++ b/tests/test-topgrade-codex-desktop-linux-update.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UPDATE_SCRIPT="${REPO_ROOT}/system/usr_local_bin__topgrade-codex-desktop-linux-update"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+fail_test() {
+    echo "test-topgrade-codex-desktop-linux-update: $*" >&2
+    exit 1
+}
+
+initialize_repo() {
+    local repo_dir="$1"
+    local origin_url="$2"
+
+    mkdir -p "$repo_dir"
+    git init -q --initial-branch=main "$repo_dir"
+    git -C "$repo_dir" config user.name "Codex Test"
+    git -C "$repo_dir" config user.email "codex-test@example.invalid"
+    printf 'initial\n' > "$repo_dir/tracked.txt"
+    mkdir -p "$repo_dir/contrib/user-local-install"
+    printf '#!/usr/bin/env bash\n' > "$repo_dir/contrib/user-local-install/install-user-local.sh"
+    chmod +x "$repo_dir/contrib/user-local-install/install-user-local.sh"
+    git -C "$repo_dir" add tracked.txt contrib/user-local-install/install-user-local.sh
+    git -C "$repo_dir" commit -q -m "Initial test commit"
+    git -C "$repo_dir" remote add origin "$origin_url"
+    git -C "$repo_dir" update-ref refs/remotes/origin/main HEAD
+}
+
+export HOME="${TEST_ROOT}/home"
+export XDG_DATA_HOME="${HOME}/.local/share"
+export XDG_STATE_HOME="${HOME}/.local/state"
+unset CODEX_DESKTOP_LINUX_REPO
+mkdir -p "$HOME"
+
+# shellcheck disable=SC1090
+source "$UPDATE_SCRIPT"
+
+legacy_repo="${HOME}/codex-desktop-linux"
+initialize_repo "$legacy_repo" "https://example.invalid/user/codex-desktop-linux.git"
+printf 'dirty user work\n' >> "$legacy_repo/tracked.txt"
+legacy_head_before="$(git -C "$legacy_repo" rev-parse HEAD)"
+legacy_status_before="$(git -C "$legacy_repo" status --porcelain --untracked-files=normal)"
+
+production_canonical_url="$CANONICAL_REPO_URL"
+canonical_test_repo="${TEST_ROOT}/canonical-source"
+initialize_repo "$canonical_test_repo" "https://example.invalid/canonical-source.git"
+
+initialize_repo "$MANAGED_REPO_DIR" "https://github.com/jheinem1/codex-desktop-linux.git"
+printf 'obsolete fork state\n' >> "$MANAGED_REPO_DIR/tracked.txt"
+git -C "$MANAGED_REPO_DIR" add tracked.txt
+git -C "$MANAGED_REPO_DIR" commit -q -m "Obsolete managed source commit"
+git -C "$MANAGED_REPO_DIR" update-ref refs/remotes/origin/main HEAD
+managed_head_before="$(git -C "$MANAGED_REPO_DIR" rev-parse HEAD)"
+CANONICAL_REPO_URL="$canonical_test_repo"
+
+prepare_source_repo
+
+[ "$SOURCE_MODE" = "managed" ] || fail_test "wrong-origin managed checkout was not treated as managed"
+[ "$(git -C "$MANAGED_REPO_DIR" remote get-url origin)" = "$canonical_test_repo" ] \
+    || fail_test "wrong-origin managed checkout was not repointed to canonical"
+[ "$(git -C "$MANAGED_REPO_DIR" rev-parse HEAD)" = "$(git -C "$canonical_test_repo" rev-parse HEAD)" ] \
+    || fail_test "wrong-origin managed checkout did not converge to canonical HEAD"
+[ "$(git -C "$MANAGED_REPO_DIR" rev-parse HEAD)" != "$managed_head_before" ] \
+    || fail_test "wrong-origin managed checkout retained its obsolete history"
+[ "$(git -C "$legacy_repo" rev-parse HEAD)" = "$legacy_head_before" ] \
+    || fail_test "managed-origin repair changed the dirty legacy checkout HEAD"
+[ "$(git -C "$legacy_repo" status --porcelain --untracked-files=normal)" = "$legacy_status_before" ] \
+    || fail_test "managed-origin repair changed the dirty legacy checkout worktree"
+
+rm -rf "$MANAGED_REPO_DIR"
+CANONICAL_REPO_URL="$production_canonical_url"
+
+# Keep the test offline while exercising the complete managed-source selection
+# and convergence path with a real temporary Git checkout.
+clone_managed_repo() {
+    initialize_repo "$MANAGED_REPO_DIR" "$CANONICAL_REPO_URL"
+}
+
+fetch_source_repo() {
+    :
+}
+
+prepare_source_repo
+
+[ "$SOURCE_MODE" = "managed" ] || fail_test "default source mode was not managed"
+[ "$REPO_DIR" = "$MANAGED_REPO_DIR" ] || fail_test "default source did not use the managed checkout"
+[ "$REPO_DIR" != "$legacy_repo" ] || fail_test "dirty legacy checkout was selected"
+[ "$(git -C "$legacy_repo" rev-parse HEAD)" = "$legacy_head_before" ] \
+    || fail_test "dirty legacy checkout HEAD changed"
+[ "$(git -C "$legacy_repo" status --porcelain --untracked-files=normal)" = "$legacy_status_before" ] \
+    || fail_test "dirty legacy checkout worktree changed"
+
+wrong_origin_repo="${TEST_ROOT}/explicit-wrong-origin"
+initialize_repo "$wrong_origin_repo" "https://example.invalid/not-canonical.git"
+wrong_origin_head_before="$(git -C "$wrong_origin_repo" rev-parse HEAD)"
+CODEX_DESKTOP_LINUX_REPO="$wrong_origin_repo"
+
+if (prepare_source_repo) 2>"${TEST_ROOT}/explicit-wrong-origin.err"; then
+    fail_test "explicit checkout with the wrong origin was accepted"
+fi
+grep -q 'origin is not the canonical source' "${TEST_ROOT}/explicit-wrong-origin.err" \
+    || fail_test "wrong-origin explicit checkout did not fail clearly"
+[ "$(git -C "$wrong_origin_repo" rev-parse HEAD)" = "$wrong_origin_head_before" ] \
+    || fail_test "wrong-origin explicit checkout HEAD changed"
+
+fast_forward_repo="${TEST_ROOT}/explicit-fast-forward"
+initialize_repo "$fast_forward_repo" "$CANONICAL_REPO_URL"
+printf 'upstream update\n' >> "$fast_forward_repo/tracked.txt"
+git -C "$fast_forward_repo" add tracked.txt
+git -C "$fast_forward_repo" commit -q -m "Upstream test update"
+git -C "$fast_forward_repo" update-ref refs/remotes/origin/main HEAD
+fast_forward_target="$(git -C "$fast_forward_repo" rev-parse HEAD)"
+git -C "$fast_forward_repo" reset -q --hard HEAD^
+CODEX_DESKTOP_LINUX_REPO="$fast_forward_repo"
+
+prepare_source_repo
+[ "$SOURCE_MODE" = "explicit" ] || fail_test "explicit override was not preserved"
+[ "$(git -C "$fast_forward_repo" rev-parse HEAD)" = "$fast_forward_target" ] \
+    || fail_test "clean explicit checkout did not fast-forward"
+
+explicit_repo="${TEST_ROOT}/explicit-dirty"
+initialize_repo "$explicit_repo" "$CANONICAL_REPO_URL"
+printf 'dirty override\n' >> "$explicit_repo/tracked.txt"
+explicit_head_before="$(git -C "$explicit_repo" rev-parse HEAD)"
+explicit_status_before="$(git -C "$explicit_repo" status --porcelain --untracked-files=normal)"
+CODEX_DESKTOP_LINUX_REPO="$explicit_repo"
+
+if (prepare_source_repo) 2>"${TEST_ROOT}/explicit-dirty.err"; then
+    fail_test "dirty explicit checkout was accepted"
+fi
+grep -q 'CODEX_DESKTOP_LINUX_REPO is dirty' "${TEST_ROOT}/explicit-dirty.err" \
+    || fail_test "dirty explicit checkout did not fail clearly"
+[ "$(git -C "$explicit_repo" rev-parse HEAD)" = "$explicit_head_before" ] \
+    || fail_test "dirty explicit checkout HEAD changed"
+[ "$(git -C "$explicit_repo" status --porcelain --untracked-files=normal)" = "$explicit_status_before" ] \
+    || fail_test "dirty explicit checkout worktree changed"
+
+diverged_repo="${TEST_ROOT}/explicit-diverged"
+initialize_repo "$diverged_repo" "$CANONICAL_REPO_URL"
+printf 'local commit\n' >> "$diverged_repo/tracked.txt"
+git -C "$diverged_repo" add tracked.txt
+git -C "$diverged_repo" commit -q -m "Local divergent commit"
+diverged_head_before="$(git -C "$diverged_repo" rev-parse HEAD)"
+CODEX_DESKTOP_LINUX_REPO="$diverged_repo"
+
+if (prepare_source_repo) 2>"${TEST_ROOT}/explicit-diverged.err"; then
+    fail_test "diverged explicit checkout was accepted"
+fi
+grep -q 'has local or diverged commits' "${TEST_ROOT}/explicit-diverged.err" \
+    || fail_test "diverged explicit checkout did not fail clearly"
+[ "$(git -C "$diverged_repo" rev-parse HEAD)" = "$diverged_head_before" ] \
+    || fail_test "diverged explicit checkout HEAD changed"
+
+echo "Codex Desktop managed-source tests passed."


### PR DESCRIPTION
## Summary

- use an updater-owned clone of canonical `ilysenko/codex-desktop-linux` by default
- migrate the existing managed checkout away from the obsolete `jheinem1/codex-desktop-linux` origin
- preserve `CODEX_DESKTOP_LINUX_REPO` as an explicit clean canonical override
- reject dirty, wrong-origin, ahead, or diverged explicit checkouts before mutation
- add an offline temp-`HOME` regression test and run it in image CI

## Root cause

The live desktop was running a dirty Codex Desktop build based on a May 13 wrapper commit more than 1,200 commits behind canonical current main. The James OS Topgrade hook selected the first arbitrary home checkout and used `git pull --ff-only`; on this host that meant an even older dirty personal checkout, while the updater-owned checkout pointed to an obsolete repository. Topgrade therefore could not reliably converge the installed app to current Linux recovery fixes.

This was exposed when an expired/invalid OAuth refresh token delayed `codex app-server` initialization beyond Desktop's 30-second timeout. After reauthentication the app recovered, but the stale wrapper made recurrence and failed updates much more likely.

## Behavior

The default path is now `${XDG_DATA_HOME:-$HOME/.local/share}/codex-desktop-linux/managed-repo`. Because it is updater-owned, the hook repairs its origin to canonical and resets tracked state to `origin/main`. Personal checkouts such as `~/codex-desktop-linux` are ignored unless explicitly selected, and explicit checkouts are never modified when dirty or diverged.

## Validation

- `bash -n system/usr_local_bin__topgrade-codex-desktop-linux-update`
- `bash -n tests/test-topgrade-codex-desktop-linux-update.sh`
- focused offline managed-source regression test passed
- workflow parsed successfully as YAML
- `git diff --check`

`just`, `shellcheck`, and `actionlint` were unavailable locally.