### PR TITLE
Restore Discord Wayland input flags

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -83,7 +83,7 @@ apply_discord_runtime_fixes() {
     done
 }
 
-discord_flags="--ozone-platform=wayland --disable-vulkan"
+discord_flags="--ozone-platform=wayland --enable-features=UseOzonePlatform,WaylandWindowDecorations --ignore-gpu-blocklist --enable-gpu-rasterization --enable-zero-copy --disable-vulkan"
 
 mkdir -p "$discord_root"
 if [ ! -d "$discord_root" ]; then


### PR DESCRIPTION
## What changed

Restore Discord's explicit native Wayland/Ozone, GPU rasterization, zero-copy, and GPU blocklist override flags while continuing to disable Vulkan.

## Why

The updater-safe Vencord integration launched Discord successfully, but the reduced `--ozone-platform=wayland --disable-vulkan` flag set caused pointer movement and click handling to stop working while keyboard input and scrolling remained responsive.

The restored flag set was validated against the live Discord 1.0.149 installation: pointer input recovered, the renderer used four raster threads and zero-copy, Chromium did not add `--disable-gpu-compositing`, and the Vencord KDE idle-sync socket restarted successfully.

## Validation

- `bash -n build.sh`
- `git diff --check`
- Live Discord/Vencord launch on KDE Plasma Wayland
- Verified main and renderer command lines after relaunch
- Confirmed pointer movement and clicking with the user