### PR TITLE
Use XWayland for Discord image previews

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -83,7 +83,8 @@ apply_discord_runtime_fixes() {
     done
 }
 
-discord_flags="--ozone-platform=wayland --enable-features=UseOzonePlatform,WaylandWindowDecorations --ignore-gpu-blocklist --enable-gpu-rasterization --enable-zero-copy --disable-vulkan"
+# Native Wayland loses pointer input when Discord opens an image preview.
+discord_flags="--ozone-platform=x11 --disable-vulkan"
 
 mkdir -p "$discord_root"
 if [ ! -d "$discord_root" ]; then


### PR DESCRIPTION
## What changed

Run Discord through the X11 Ozone backend under KDE Wayland and continue disabling Vulkan.

## Why

The native Wayland flag set from #106 made Discord initially responsive, but did not fix the actual reproduction: clicking an image prevented the preview from opening and caused Discord to stop receiving pointer movement and click input. Keyboard input and scrolling continued to work, and the renderer did not crash.

The same Discord 1.0.149/Vencord installation was relaunched with `--ozone-platform=x11 --disable-vulkan`. The same image then opened normally and pointer input remained usable. Vencord's KDE idle-sync socket also restarted successfully, so lock-to-idle behavior remains available.

## Validation

- `bash -n build.sh`
- `git diff --check`
- Confirmed the live main process used `--ozone-platform=x11 --disable-vulkan`
- Reproduced the native Wayland failure by clicking an image
- Retested the same image successfully under XWayland
- Confirmed Vencord KDE idle-sync remained active