### PR TITLE
Remove Piper RPM from image

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ James OS is a custom Fedora Atomic Desktop image built using Universal Blue's to
 - Pre-installs 1Password and its CLI for password management
 - Pre-installs Visual Studio Code for development
 - Adds Konsole and Yakuake terminal emulators alongside ptyxis
-- Includes Piper for mouse configuration and CoreCtrl for power management
+- Includes the libratbag/ratbagd device-configuration backend and CoreCtrl for power management
 - Pre-installs Discord RPM
 
 ## Tech Stack

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A [Fedora Atomic](https://fedoraproject.org/atomic-desktops) image built with [U
 - Preinstalls 1Password and the 1Password CLI.
 - Adds back Konsole as a terminal option and Yakuake to complement it (ptyxis remains the default for compatibility with some Bazzite features).
 - Launches the System Update shortcut in Konsole and includes a Topgrade custom step backed by a managed clone of the canonical `codex-desktop-linux` repository. Set `CODEX_DESKTOP_LINUX_REPO` to explicitly use a clean, non-diverged canonical checkout instead.
-- Preinstalls Piper for configuring mice.
+- Preinstalls the libratbag/ratbagd backend for configuring supported devices; graphical frontends such as Piper can be installed separately.
 - Preinstalls CoreCtrl for power management.
 - Adds an Open With action in Dolphin to encode videos for Discord using CPU H.264 with a target-size popup and progress bar.
 - Installs Discord from the official RPM at image build time, patches it with a pinned Vencord build when app resources are available, and includes a KDE idle/lock watcher that can drive Discord presence over a local socket.

--- a/build.sh
+++ b/build.sh
@@ -36,10 +36,10 @@ dnf5 install -y \
   1password-cli \
   cargo \
   konsole \
+  libratbag-ratbagd \
   nodejs \
   npm \
   patch \
-  piper \
   yakuake \
   corectrl \
   kde-partitionmanager \


### PR DESCRIPTION
## What changed

- Removed the `piper` RPM from the JamesOS image package list.
- Kept `libratbag-ratbagd` installed as the device-configuration backend.
- Updated project documentation to clarify that a graphical frontend may be installed separately.

## Why

Piper can be installed and patched independently as a Flatpak, while ratbagd remains available system-wide for supported-device configuration.

## Impact

New JamesOS images no longer include the Piper RPM. Existing users can install Piper locally as a Flatpak without losing the libratbag/ratbagd service.

## Validation

- `bash -n build.sh`
- `git diff --check`
- Confirmed Fedora's Piper package depends on `libratbag-ratbagd`
