### PR TITLE
Fix Discord Plasma link handling

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -62,6 +62,10 @@ fi
 cat > /usr/bin/discord <<'EOF'
 #!/bin/sh
 
+# xdg-open needs this on Plasma 6 or it falls back to the removed kfmclient.
+export KDE_SESSION_VERSION="6"
+export KDE_FULL_SESSION="true"
+
 CHANNEL=stable
 DOWNLOAD=https://updates.discord.com/
 DIR=discord


### PR DESCRIPTION
## What

- export the Plasma 6 session markers from the image-generated Discord wrapper
- keep the existing native Wayland, Vencord, and graphics flags unchanged

## Why

The user systemd environment on the current Plasma 6.7.3 deployment has `XDG_CURRENT_DESKTOP=KDE` but does not export `KDE_SESSION_VERSION` or `KDE_FULL_SESSION`. Without those markers, `xdg-open` takes its legacy KDE fallback and tries `kfmclient` instead of the Plasma 6 opener path.

## Impact

Links opened by Discord use the correct Plasma 6 URL handler. This is limited to Discord's process environment and does not alter the desktop session globally.

## Checks

- `bash -n build.sh`
- `git diff --check`
- confirmed the booted user-manager environment lacks both Plasma session markers
- confirmed the live local Discord wrapper already uses these exports successfully
